### PR TITLE
fix: black borders in square wall

### DIFF
--- a/1080i/Includes_View_51_Wall.xml
+++ b/1080i/Includes_View_51_Wall.xml
@@ -624,7 +624,6 @@
                 <param name="height" value="view_height" />
                 <param name="itemwidth" value="item_square_width" />
                 <param name="iconheight" value="item_icon_height" />
-                <param name="aspectratio" value="keep" />
                 <param name="viewtype" value="Square Wall" />
                 <param name="viewtypename" value="icon" />
                 <param name="diffuse" value="diffuse/square-wall.png" />


### PR DESCRIPTION
using actual square thumbs in view Square Wall leaves black borders left and right, due to the squares in the skin being a bit wider then it's height.

this commit removes the aspectratio=keep setting of the view, thus resulting in the thumb filling all the space and removing the black borders.

it's handling is then similar to the Square Showcase view, where there is no aspectratio=keep setting already.