### PR TITLE
Feature/add more launchers game support

### DIFF
--- a/1080i/Defaults.xml
+++ b/1080i/Defaults.xml
@@ -207,6 +207,17 @@
     <expression name="Exp_InfoVisible">[Window.IsVisible(DialogVideoInfo.xml) | Window.IsVisible(DialogMusicInfo.xml) | Window.IsVisible(DialogAddonInfo.xml) | Window.IsVisible(1140) | Window.IsVisible(DialogPVRInfo.xml)]</expression>
 
     <expression name="Exp_IsPluginAdvancedLauncher">[String.StartsWith(Container.FolderPath,plugin://plugin.program.advanced.launcher/) | String.StartsWith(Container.FolderPath,plugin://plugin.program.advanced.emulator.launcher/) | String.StartsWith(Container.FolderPath,plugin://plugin.program.advanced.MAME.launcher/)]</expression>
+    <expression name="InGameMode">
+       [ String.Contains(Container.FolderPath,plugin://plugin.program.ael) 
+       | String.Contains(Container.FolderPath,plugin://plugin.program.advanced.launcher) 
+       | String.Contains(Container.FolderPath,plugin://plugin.program.advanced.emulator.launcher) 
+       | String.Contains(Container.FolderPath,plugin://plugin.program.akl) 
+       | String.Contains(Container.FolderPath,plugin://plugin.program.advanced.MAME.launcher) 
+       | String.Contains(Container.FolderPath,plugin://plugin.program.iagl) 
+       | Window.IsActive(games) 
+       | Container.Content(games) ]
+   </expression>
+
 
     <expression name="Exp_ShowPlotOverlay">[Control.HasFocus(9601) | [System.IdleTime(4) + Skin.HasSetting(AutoPlotOverlay) + [String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,set) | String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,season) | String.IsEqual(ListItem.DBType,video) | String.IsEqual(ListItem.DBType,artist) | String.IsEqual(ListItem.DBType,album) | String.IsEqual(ListItem.DBType,song)] + ![Window.IsVisible(DialogVideoInfo.xml) | Window.IsVisible(DialogMusicInfo.xml) | Window.IsVisible(DialogAddonInfo.xml) | Window.IsVisible(1190) | Window.IsVisible(1140)]]]</expression>
 

--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -177,7 +177,7 @@
 
     <variable name="Image_Poster">
         <value condition="!String.IsEmpty(ListItem.Art(season.poster)) + !Window.IsVisible(Home)">$INFO[ListItem.Art(season.poster)]</value>
-        <value condition="$EXP[Exp_IsPluginAdvancedLauncher]">$VAR[ROM_Simple_Art_Main]</value>
+        <value condition="$EXP[InGameMode]">$VAR[ROM_Simple_Art_Main]</value>
         <value condition="!String.IsEmpty(ListItem.Art(poster))">$INFO[ListItem.Art(poster)]</value>
         <value condition="!String.IsEmpty(ListItem.Art(tvshow.poster))">$INFO[ListItem.Art(tvshow.poster)]</value>
         <value condition="!String.IsEmpty(Container.Art(season.poster)) + !Window.IsVisible(Home)">$INFO[Container.Art(season.poster)]</value>

--- a/1080i/Includes_Items.xml
+++ b/1080i/Includes_Items.xml
@@ -1969,7 +1969,7 @@
                 <onclick condition="[Container.Content(videos) + String.IsEmpty(Skin.String(Skin.ForcedView.videos))]">AlarmClock(setviewlock,Skin.SetString(Skin.ForcedView.$INFO[Container.Content],$INFO[Container.Viewmode]),00:01,silent)</onclick>
                 <visible>Window.IsVisible(MyVideoNav.xml) | Window.IsVisible(MyMusicNav.xml) | Window.IsVisible(AddonBrowser.xml) | Window.IsVisible(MyPics.xml) | Window.IsVisible(MyPrograms.xml) | Window.IsVisible(MyGames.xml)</visible>
                 <visible>!Skin.HasSetting(KioskMode)</visible>
-                <visible>!$EXP[Exp_IsPluginAdvancedLauncher]</visible>
+                <visible>!$EXP[InGameMode]</visible>
             </item>
 
             <!-- Sort -->

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -340,7 +340,7 @@
     </variable>
 
     <variable name="Label_SubTitle">
-        <value condition="[String.StartsWith(Container.FolderPath,plugin://plugin.program.advanced.launcher/) | String.StartsWith(Container.FolderPath,plugin://plugin.program.advanced.emulator.launcher/) | String.StartsWith(Container.FolderPath,plugin://plugin.program.advanced.MAME.launcher/)]">$INFO[ListItem.Property(platform),[COLOR=main_fg_100],[/COLOR]]$INFO[ListItem.Studio,  |  [COLOR=main_fg_100],[/COLOR]]$INFO[ListItem.Year,  |  [COLOR=main_fg_100],[/COLOR]]$INFO[ListItem.Property(nplayers),  |  [COLOR=main_fg_100], $LOCALIZE[31308][/COLOR]]$INFO[ListItem.Property(ESRB),  |  [COLOR=main_fg_100],[/COLOR]]</value>
+        <value condition="$EXP[InGameMode]">$INFO[ListItem.Property(platform),[COLOR=main_fg_100],[/COLOR]]$INFO[ListItem.Studio,  |  [COLOR=main_fg_100],[/COLOR]]$INFO[ListItem.Year,  |  [COLOR=main_fg_100],[/COLOR]]$INFO[ListItem.Property(nplayers),  |  [COLOR=main_fg_100], $LOCALIZE[31308][/COLOR]]$INFO[ListItem.Property(ESRB),  |  [COLOR=main_fg_100],[/COLOR]]</value>
 
         <value condition="!String.IsEmpty(ListItem.Property(Artist_Genre)) + Container.Content(artists)">$INFO[Window(Home).Property(TMDbHelper.ListItem.AlbumCount),[COLOR=main_fg_100], $LOCALIZE[132][/COLOR]  |  ]$INFO[ListItem.Property(Artist_Genre),[COLOR=main_fg_100],[/COLOR]]$INFO[ListItem.Property(Artist_YearsActive),  |  [COLOR=main_fg_100],[/COLOR]]</value>
         

--- a/1080i/Includes_View_50_List.xml
+++ b/1080i/Includes_View_50_List.xml
@@ -16,7 +16,7 @@
                 <param name="viewtype" value="List" />
                 <param name="viewtypename" value="list" />
                 <param name="forced" value="true" />
-                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(actors) | [Container.Content(files) + Window.IsVisible(MyVideoNav.xml) + !String.IsEqual(Container.FolderPath,plugin://plugin.video.youtube/) + !String.IsEmpty(Container.PluginName)] | Window.IsVisible(videoplaylist) | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(actors) | [Container.Content(files) + Window.IsVisible(MyVideoNav.xml) + !String.IsEqual(Container.FolderPath,plugin://plugin.video.youtube/) + !String.IsEmpty(Container.PluginName)] | Window.IsVisible(videoplaylist) | $EXP[InGameMode]" />
             </include>
         </control>
     </include>
@@ -40,7 +40,7 @@
                     <param name="viewtype" value="List" />
                     <param name="viewtypename" value="list" />
                     <param name="forced" value="true" />
-                    <param name="visible" value="![Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(actors) | [Container.Content(files) + Window.IsVisible(MyVideoNav.xml) + !String.IsEqual(Container.FolderPath,plugin://plugin.video.youtube/) + !String.IsEmpty(Container.PluginName)] | Window.IsVisible(videoplaylist)] | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                    <param name="visible" value="![Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(actors) | [Container.Content(files) + Window.IsVisible(MyVideoNav.xml) + !String.IsEqual(Container.FolderPath,plugin://plugin.video.youtube/) + !String.IsEmpty(Container.PluginName)] | Window.IsVisible(videoplaylist)] | $EXP[InGameMode]" />
                 </include>
             </control>
         </control>
@@ -80,7 +80,7 @@
                 <param name="viewtypename" value="info" />
                 <param name="forced" value="true" />
                 <param name="flipsides" value="Skin.HasSetting(FlipSide)" />
-                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | Container.Content(videos) | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | Container.Content(videos) | $EXP[InGameMode]" />
             </include>
             <include content="View_522_Showcase_Seasons_Info">
                 <param name="visible" value="true" />
@@ -103,7 +103,7 @@
                 <param name="viewtypename" value="biginfo" />
                 <param name="forced" value="true" />
                 <param name="flipsides" value="Skin.HasSetting(FlipSide)" />
-                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | $EXP[InGameMode]" />
             </include>
             <include>View_502_List_Info</include>
         </control>
@@ -119,7 +119,7 @@
                 <width>1790</width>
                 <top>-15</top>
                 <left>-15</left>
-                <visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | $EXP[Exp_IsPluginAdvancedLauncher]</visible>
+                <visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | $EXP[InGameMode]</visible>
                 <height>840</height>
                 <include>View_Vertical</include>
                 <movement>2</movement>
@@ -345,7 +345,7 @@
                         <param name="forced" value="true" />
                         <param name="itemlayout" value="View_504_Itemlayout" />
                         <param name="flipsides" value="Skin.HasSetting(FlipSide)" />
-                        <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                        <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | $EXP[InGameMode]" />
                     </include>
                     <include content="View_504_Info">
                         <param name="visible" value="true" />
@@ -402,10 +402,10 @@
                             <width>500</width>
                             <label>$PARAM[title]</label>
                         </control>
-                        <include condition="!$EXP[Exp_IsPluginAdvancedLauncher]" content="Object_Info_Line">
+                        <include condition="!$EXP[InGameMode]" content="Object_Info_Line">
                             <param name="nextaired" value="false" />
                         </include>
-                        <include condition="$EXP[Exp_IsPluginAdvancedLauncher]">View_540_ROM_Details</include>
+                        <include condition="$EXP[InGameMode]">View_540_ROM_Details</include>
                         <control type="textbox">
                             <top>25</top>
                             <font>font_plotbox</font>
@@ -472,16 +472,16 @@
                         <height>52</height>
                         <label>$VAR[Label_List_Title]</label>
                     </control>
-                    <include condition="!$EXP[Exp_IsPluginAdvancedLauncher]">Object_Info_Line</include>
-                    <include condition="$EXP[Exp_IsPluginAdvancedLauncher]">View_540_ROM_Details</include>
-                    <include content="Object_Info_Ratings" condition="!$EXP[Exp_IsPluginAdvancedLauncher]">
+                    <include condition="!$EXP[InGameMode]">Object_Info_Line</include>
+                    <include condition="$EXP[InGameMode]">View_540_ROM_Details</include>
+                    <include content="Object_Info_Ratings" condition="!$EXP[InGameMode]">
                         <param name="top" value="-10" />
                         <param name="imdbvotes" value="false" />
                         <param name="top250" value="false" />
                         <param name="oscars" value="false" />
                     </include>
                     <control type="textbox">
-                        <visible>!$EXP[Exp_IsPluginAdvancedLauncher]</visible>
+                        <visible>!$EXP[InGameMode]</visible>
                         <top>25</top>
                         <font>font_plotbox</font>
                         <textcolor>main_fg_70</textcolor>
@@ -491,7 +491,7 @@
                         <label>$VAR[Label_Plot]</label>
                     </control>
                     <control type="textbox">
-                        <visible>$EXP[Exp_IsPluginAdvancedLauncher]</visible>
+                        <visible>$EXP[InGameMode]</visible>
                         <top>25</top>
                         <font>font_plotbox</font>
                         <textcolor>main_fg_70</textcolor>

--- a/1080i/Includes_View_51_Wall.xml
+++ b/1080i/Includes_View_51_Wall.xml
@@ -372,7 +372,7 @@
         <param name="aspectratio" default="scale" />
         <param name="diffuse" default="diffuse/poster-wall.png" />
         <!-- FIX ME -->
-        <param name="stretchsides" default="Control.IsVisible(512) + !Window.IsVisible(home) + !$EXP[Exp_IsPluginAdvancedLauncher]" />
+        <param name="stretchsides" default="Control.IsVisible(512) + !Window.IsVisible(home) + !$EXP[InGameMode]" />
         <definition>
             <control type="group">
                 <right>10</right>
@@ -610,7 +610,7 @@
                 <param name="viewtype" value="Poster Wall" />
                 <param name="viewtypename" value="icon" />
                 <param name="forced" value="true" />
-                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(actors) | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(actors) | $EXP[InGameMode]" />
                 <include>View_Vertical_Movement</include>
             </include>
         </control>
@@ -628,7 +628,7 @@
                 <param name="viewtypename" value="icon" />
                 <param name="diffuse" value="diffuse/square-wall.png" />
                 <param name="forced" value="true" />
-                <param name="visible" value="Container.Content(artists) | Container.Content(albums) | Container.Content(games) | Container.Content(programs) | Container.Content(addons) | Container.Content(images) | Container.Content() | Container.Content(files) | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="Container.Content(artists) | Container.Content(albums) | Container.Content(games) | Container.Content(programs) | Container.Content(addons) | Container.Content(images) | Container.Content() | Container.Content(files) | $EXP[InGameMode]" />
                 <include>View_Vertical_Movement</include>
             </include>
         </control>
@@ -651,7 +651,7 @@
                 <param name="viewtypename" value="wide" />
                 <param name="forced" value="true" />
                 <param name="labelinclude" value="View_51_Wall_Landscape_Label" />
-                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | Container.Content(videos) | Container.Content(images) | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | Container.Content(videos) | Container.Content(images) | $EXP[InGameMode]" />
                 <include>View_Vertical_Movement</include>
             </include>
         </control>
@@ -717,7 +717,7 @@
                 <param name="viewtypename" value="icon" />
                 <param name="controllayout" value="View_514_Wall_Info_Layout" />
                 <param name="forced" value="true" />
-                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | $EXP[InGameMode]" />
                 <width>1028.56</width>
                 <include>View_Vertical_Movement</include>
             </include>
@@ -741,7 +741,7 @@
                 <param name="viewtypename" value="icon" />
                 <param name="controllayout" value="View_514_Wall_Info_Layout" />
                 <param name="forced" value="true" />
-                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | !$EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | !$EXP[InGameMode]" />
                 <width>1028.56</width>
                 <include>View_Vertical_Movement</include>
             </include>
@@ -774,7 +774,7 @@
                 <param name="viewtypename" value="wide" />
                 <param name="forced" value="true" />
                 <param name="labelinclude" value="Defs_Null" />
-                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | Container.Content(videos) | Container.Content(images) | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | Container.Content(videos) | Container.Content(images) | $EXP[InGameMode]" />
                 <include>View_Vertical_Movement</include>
             </include>
         </control>

--- a/1080i/Includes_View_52_Showcase.xml
+++ b/1080i/Includes_View_52_Showcase.xml
@@ -114,7 +114,7 @@
                     <height>390</height>
                     <texture background="true">$VAR[Image_ClearLogo]</texture>
                     <aspectratio align="right" aligny="bottom">keep</aspectratio>
-                    <visible>!$EXP[Exp_IsPluginAdvancedLauncher] + [!String.IsEmpty(ListItem.Art(clearlogo)) | !String.IsEmpty(ListItem.Art(tvshow.clearlogo))] + [[String.IsEmpty(ListItem.Art(landscape)) + String.IsEmpty(ListItem.Art(tvshow.landscape))] | [[!String.IsEmpty(ListItem.Art(tvshow.landscape)) | !String.IsEmpty(ListItem.Art(landscape))] + !Skin.HasSetting(LandscapeArt)] | [!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))]]</visible>
+                    <visible>!$EXP[InGameMode] + [!String.IsEmpty(ListItem.Art(clearlogo)) | !String.IsEmpty(ListItem.Art(tvshow.clearlogo))] + [[String.IsEmpty(ListItem.Art(landscape)) + String.IsEmpty(ListItem.Art(tvshow.landscape))] | [[!String.IsEmpty(ListItem.Art(tvshow.landscape)) | !String.IsEmpty(ListItem.Art(landscape))] + !Skin.HasSetting(LandscapeArt)] | [!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))]]</visible>
                 </control>
                 <control type="group">
                     <include content="View_540_Platform_Icon">
@@ -137,12 +137,12 @@
                             <width>630</width>
                             <label>$PARAM[title]</label>
                         </control>
-                        <include condition="$EXP[Exp_IsPluginAdvancedLauncher]" content="View_540_ROM_Details">
+                        <include condition="$EXP[InGameMode]" content="View_540_ROM_Details">
                         </include>
-                        <include condition="$PARAM[seasons] + !$EXP[Exp_IsPluginAdvancedLauncher]" content="Object_Info_Line">
+                        <include condition="$PARAM[seasons] + !$EXP[InGameMode]" content="Object_Info_Line">
                             <param name="nextaired" value="false" />
                         </include>
-                        <include condition="!$PARAM[seasons] + !$EXP[Exp_IsPluginAdvancedLauncher]" content="Object_Info_Line">
+                        <include condition="!$PARAM[seasons] + !$EXP[InGameMode]" content="Object_Info_Line">
                             <param name="nextaired" value="false" />
                             <param name="label" value="$INFO[Container($PARAM[id]).ListItem.MPAA]" />
                             <param name="container" value="Container($PARAM[id])." />
@@ -357,7 +357,7 @@
                 <param name="labelinclude" value="Defs_Null" />
                 <param name="controltype" value="fixedlist" />
                 <param name="controllayout" value="View_52_Showcase_Layout" />
-                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | $EXP[InGameMode]" />
                 <param name="viewtype" value="Poster Showcase" />
                 <param name="viewtypename" value="wrap" />
                 <param name="forced" value="true" />
@@ -401,7 +401,7 @@
                 <param name="orientation" value="horizontal" />
                 <param name="controltype" value="fixedlist" />
                 <param name="controllayout" value="View_520_Showcase_Layout" />
-                <param name="visible" value="Container.Content(artists) | Container.Content(albums) | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="Container.Content(artists) | Container.Content(albums) | $EXP[InGameMode]" />
                 <param name="viewtype" value="Square Showcase" />
                 <param name="viewtypename" value="wrap" />
                 <param name="forced" value="true" />
@@ -426,7 +426,7 @@
                 <param name="orientation" value="horizontal" />
                 <param name="controltype" value="fixedlist" />
                 <param name="controllayout" value="View_52_Showcase_Aura_Layout" />
-                <param name="visible" value="Container.Content(artists) | Container.Content(albums) | Container.Content(addons) | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="Container.Content(artists) | Container.Content(albums) | Container.Content(addons) | $EXP[InGameMode]" />
                 <param name="viewtype" value="Square Showcase" />
                 <param name="viewtypename" value="wrap" />
                 <param name="forced" value="true" />
@@ -455,7 +455,7 @@
                 <param name="icon" value="$VAR[Image_Landscape]" />
                 <param name="clearlogo" value="[!String.IsEmpty(ListItem.Art(clearlogo)) | !String.IsEmpty(ListItem.Art(tvshow.clearlogo))] + [[String.IsEmpty(ListItem.Art(landscape)) + String.IsEmpty(ListItem.Art(tvshow.landscape))] | [[!String.IsEmpty(ListItem.Art(tvshow.landscape)) | !String.IsEmpty(ListItem.Art(landscape))] + !Skin.HasSetting(LandscapeArt)] | [!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))]]" />
                 <param name="iconheight" value="item_icon_height" />
-                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | Container.Content(videos) | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | Container.Content(videos) | $EXP[InGameMode]" />
                 <param name="viewtype" value="Showcase Flix View" />
                 <param name="viewtypename" value="wrap" />
                 <param name="forced" value="true" />
@@ -483,7 +483,7 @@
                 <param name="icon" value="$VAR[Image_Landscape]" />
                 <param name="clearlogo" value="[!String.IsEmpty(ListItem.Art(clearlogo)) | !String.IsEmpty(ListItem.Art(tvshow.clearlogo))] + [[String.IsEmpty(ListItem.Art(landscape)) + String.IsEmpty(ListItem.Art(tvshow.landscape))] | [[!String.IsEmpty(ListItem.Art(tvshow.landscape)) | !String.IsEmpty(ListItem.Art(landscape))] + !Skin.HasSetting(LandscapeArt)] | [!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))]]" />
                 <param name="iconheight" value="item_icon_height" />
-                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | Container.Content(videos) | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | Container.Content(videos) | $EXP[InGameMode]" />
                 <param name="viewtype" value="Landscape Showcase" />
                 <param name="viewtypename" value="wrap" />
                 <param name="forced" value="true" />
@@ -509,7 +509,7 @@
                 <param name="icon" value="$VAR[Image_Landscape]" />
                 <param name="clearlogo" value="[!String.IsEmpty(ListItem.Art(clearlogo)) | !String.IsEmpty(ListItem.Art(tvshow.clearlogo))] + [[String.IsEmpty(ListItem.Art(landscape)) + String.IsEmpty(ListItem.Art(tvshow.landscape))] | [[!String.IsEmpty(ListItem.Art(tvshow.landscape)) | !String.IsEmpty(ListItem.Art(landscape))] + !Skin.HasSetting(LandscapeArt)] | [!String.IsEmpty(ListItem.Art(thumb)) + [String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)] + String.IsEmpty(ListItem.Property(airday))]]" />
                 <param name="iconheight" value="item_icon_height" />
-                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | Container.Content(videos) | $EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | Container.Content(videos) | $EXP[InGameMode]" />
                 <param name="viewtype" value="Landscape Showcase" />
                 <param name="viewtypename" value="wrap" />
                 <param name="forced" value="true" />

--- a/1080i/Includes_View_53_Poster.xml
+++ b/1080i/Includes_View_53_Poster.xml
@@ -25,8 +25,8 @@
                         <textcolor>main_fg_100</textcolor>
                         <font>font_title</font>
                     </control>
-                    <include condition="!$EXP[Exp_IsPluginAdvancedLauncher]">Object_Info_Line</include>
-                    <include condition="$EXP[Exp_IsPluginAdvancedLauncher]">View_540_ROM_Details</include>
+                    <include condition="!$EXP[InGameMode]">Object_Info_Line</include>
+                    <include condition="$EXP[InGameMode]">View_540_ROM_Details</include>
                     <control type="textbox">
                         <top>20</top>
                         <label fallback="19055">$VAR[Label_Plot]</label>
@@ -47,7 +47,7 @@
                 <orientation>horizontal</orientation>
                 <pagecontrol>62</pagecontrol>
                 <scrolltime tween="quadratic">400</scrolltime>
-                <visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | $EXP[Exp_IsPluginAdvancedLauncher]</visible>
+                <visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | $EXP[InGameMode]</visible>
                 <viewtype label="$LOCALIZE[31262]">bigicon</viewtype>
                 <include content="View_Forced">
                     <param name="string" value="$LOCALIZE[31262]" />

--- a/1080i/Includes_View_54_AEL.xml
+++ b/1080i/Includes_View_54_AEL.xml
@@ -172,7 +172,7 @@
                 <param name="forced" value="true" />
                 <param name="flipsides" value="Skin.HasSetting(FlipSide)" />
                 <param name="focustrailer" value="true" />
-                <param name="visible" value="$EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="$EXP[InGameMode]" />
             </include>
             <include>View_540_List_Info</include>
         </control>
@@ -189,7 +189,7 @@
                 <param name="viewtypename" value="icon" />
                 <param name="controllayout" value="View_514_Wall_Info_Layout" />
                 <param name="forced" value="true" />
-                <param name="visible" value="$EXP[Exp_IsPluginAdvancedLauncher]" />
+                <param name="visible" value="$EXP[InGameMode]" />
                 <param name="focustrailer" value="true" />
                 <param name="aspectratio" value="keep" />
                 <width>1028.56</width>

--- a/1080i/MyGames.xml
+++ b/1080i/MyGames.xml
@@ -3,15 +3,35 @@
 <window id="2">
     <defaultcontrol always="true">500</defaultcontrol>
     <menucontrol>300</menucontrol>
-    <views>500,510</views>    
+    <views>525,500,501,502,504,503,51,510,511,512,513,514,515,52,520,521,522,524,53,523,540,541</views>    
     <controls>
         <include>Global_Background</include>
         <include>Topbar</include>
         <control type="group">
             <visible allowhiddenfocus="true">!$EXP[Exp_ShowPlotOverlay]</visible>
             <include>Animation_FadeInOut</include>
+            <include>View_525_Showcase_Flix</include>
             <include>View_500_List_Square</include>
+            <include>View_501_List_MediaInfo</include>
+            <include>View_502_List_MediaInfo_Extended</include>
+            <include>View_503_List_Banners</include>
+            <include>View_504_List_TriPanel</include>
+            <include>View_51_Wall</include>
             <include>View_510_Wall_Square</include>
+            <include>View_511_Wall_Landscape</include>
+            <include>View_512_Wall_Icons</include>
+            <include>View_513_Wall_Circle</include>
+            <include>View_514_Wall_Info</include>
+            <include>View_515_Wall_Landscape_Small</include>
+            <include>View_52_Showcase</include>
+            <include>View_520_Showcase_Square</include>
+            <include>View_521_Showcase_Landscape</include>
+            <include>View_522_Showcase_Seasons</include>
+            <include>View_523_Showcase_Lovefilm</include>
+            <include>View_524_Showcase_Seasons</include>
+            <include>View_53_Poster</include>
+            <include>View_540_List_ROM_Info</include>
+            <include>View_541_Wall_Info</include>
         </control>
 
         <control type="list" id="300">

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="skin.arctic.zephyr.2.resurrection.mod" name="Arctic: Zephyr 2 - Resurrection" provider-name="jurialmunkey, pkscout, nfm886" version="0.7.6">
+<addon id="skin.arctic.zephyr.2.resurrection.mod" name="Arctic: Zephyr 2 - Resurrection" provider-name="jurialmunkey, pkscout, nfm886" version="0.7.7">
     <requires>
         <import addon="xbmc.gui" version="5.15.0" />
         <import addon="script.skinshortcuts" version="1.1.1" />

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="skin.arctic.zephyr.2.resurrection.mod" name="Arctic: Zephyr 2 - Resurrection" provider-name="jurialmunkey, pkscout, nfm886" version="0.7.7">
+<addon id="skin.arctic.zephyr.2.resurrection.mod" name="Arctic: Zephyr 2 - Resurrection" provider-name="jurialmunkey, pkscout, nfm886" version="0.7.6">
     <requires>
         <import addon="xbmc.gui" version="5.15.0" />
         <import addon="script.skinshortcuts" version="1.1.1" />


### PR DESCRIPTION
Extended support for more launchers like AEL.
- Changed the expression to support all kinds of launchers
- Changed all the previous 'Exp_IsPluginAdvancedLauncher' references to 'InGamesMode'
- Added the same views from MyPrograms.xml to MyGames.xml